### PR TITLE
Allow socket to send broadcast packets.

### DIFF
--- a/pyping/core.py
+++ b/pyping/core.py
@@ -303,6 +303,8 @@ class Ping(object):
 			if self.bind:
 				current_socket.bind((self.bind, 0)) # Port number is irrelevant for ICMP
 
+			current_socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+
 		except socket.error, (errno, msg):
 			if errno == 1:
 				# Operation not permitted - Add more information to traceback


### PR DESCRIPTION
Without this I get access denied whilst trying to send broadcast packets even running as root.

This was on the kernel `Linux raspberrypi 3.12.30+ #717 PREEMPT Fri Oct 17 18:46:31 BST 2014 armv6l GNU/Linux`

And `Raspbian GNU/Linux jessie/sid`
